### PR TITLE
Added res.flash which handles flashing on both the current response and a redirect

### DIFF
--- a/lib/flashify.js
+++ b/lib/flashify.js
@@ -23,19 +23,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
  var flashify;
 
  flashify = function(req, res, next) {
    var f, flash, _i, _len, _ref;
    flash = [];
-   
+
    // Make sure we have session support
    if(req.session == undefined ) throw Error('Sessions must be enabled for Flashify to work.');
-   
+
    /**
     * Set request flash for user
-    * 
+    *
     * If only 1 argument is passed, flashify will use that value
     * as the message. If the same type is used, it will queue the messages
     * into a convenient array.
@@ -51,12 +51,12 @@
     * @return {void}
     * @api private
     */
-    
+
    req.flash = function(type, message) {
      if (!(req.session.flash != null)) {
        req.session.flash = [];
      }
-     
+
      // Set the default type if only 1 argument passed
      if (arguments.length === 1) {
        message = type;
@@ -67,7 +67,23 @@
        message: message
      });
    };
-   
+
+    res.flash = function(type, message) {
+      res.locals.flash = res.locals.flash || [];
+      res.locals.flash[type] = res.locals.flash[type] || [];
+      res.locals.flash[type].push(message);
+    };
+
+    res.oldRedirect = res.redirect;
+    res.redirect = function() {
+      for (var type in res.locals.flash) {
+        res.locals.flash[type].forEach(function(message) {
+          req.flash(type, message);
+        });
+      }
+      res.oldRedirect.apply(this, arguments);
+    };
+
    // If we have any flash messages, stack them up
    if (req.session.flash != null) {
      _ref = req.session.flash;
@@ -81,10 +97,10 @@
        }
      }
    }
-   
+
    res.locals.flash = flash;
    delete req.session.flash;
-   
+
    // Continue on with application
    return next();
  };


### PR DESCRIPTION
The problem is that req.flash only works on redirects. I added res.flash to flash on the current response. If you redirect after flashing, it does the same thing req.flash normally does. This simplifies the API to one call for flashing on the same response and on a redirect.
