### PR TITLE
Normalize the behaviour of res and req flash

### DIFF
--- a/lib/flashify.js
+++ b/lib/flashify.js
@@ -69,6 +69,11 @@
    };
 
     res.flash = function(type, message) {
+      // Set the default type if only 1 argument passed
+      if (arguments.length === 1) {
+        message = type;
+        type = 'message';
+      }
       res.locals.flash = res.locals.flash || [];
       res.locals.flash[type] = res.locals.flash[type] || [];
       res.locals.flash[type].push(message);


### PR DESCRIPTION
The `res.flash` function doesn't behave the same way the `req.flash` when a type is not provided.
With this pull request the default message type is `message` just like when you use the flash function of `req`.

Great npm package btw :smile:.
